### PR TITLE
Spec doesn't actually require whitespace between url and format

### DIFF
--- a/src/grammar/grammar.peg
+++ b/src/grammar/grammar.peg
@@ -18,7 +18,7 @@ sourceEntry
   / localEntry
 
 urlEntry
-  = url:url whitespace+ format:format  { return {url: url, format: format}; }
+  = url:url whitespace* format:format  { return {url: url, format: format}; }
   / url:url  { return {url: url}; }
 
 url

--- a/test/jest/index.test.ts
+++ b/test/jest/index.test.ts
@@ -79,6 +79,15 @@ describe("Parser", () => {
             }]);
         });
 
+        it("should parse no white space between a format", () => {
+            const parse = parser.parse('url("font.woff")format("woff")');
+
+            expect(parse).toEqual([{
+                url: 'font.woff',
+                format: 'woff'
+            }]);
+        });
+
         it("should handle an empty string", () => {
             const parse = parser.parse("");
 


### PR DESCRIPTION
We ran into this problem in the field, checked the following CSS against multiple parsers and they seem to accept it:

```css
@font-face {
  font-family:TexGyreHerosNormal;
  src:url(texgyreheros-regular.686a789f.woff)format("woff");
  font-weight:400
}
```

As far as we can tell, the spec doesn't _require_ a space between `url` and `format`, so this makes the white space optional.