### PR TITLE
support CSS Fonts Module Level 4

### DIFF
--- a/src/grammar/grammar.peg
+++ b/src/grammar/grammar.peg
@@ -1,8 +1,8 @@
 /*
- * The @font-face src grammar used. http://www.w3.org/TR/css-fonts-3/#src-desc
+ * The @font-face src grammar used. https://www.w3.org/TR/css-fonts-4/#font-face-src-parsing
  *
  * Update the generated parser by running
- *   $ ./node_modules/.bin/pegjs lib/grammar/grammar.peg lib/grammar/index.js
+ *   $ npm run build:grammar
  */
 
 start
@@ -17,15 +17,22 @@ sourceEntry
   = urlEntry
   / localEntry
 
-urlEntry
-  = url:url whitespace* format:format  { return {url: url, format: format}; }
-  / url:url  { return {url: url}; }
+urlEntry = url:url format:format? tech:tech? { 
+  return { 
+    url: url, 
+    format: format == null ? undefined : format,
+    tech: tech == null ? undefined : tech,
+  };
+}
 
 url
   = "url(" value:value ")" { return value; }
 
 format
-  = "format(" value:value ")" { return value; }
+  = whitespace* "format(" value:value ")" { return value; }
+
+tech 
+  = whitespace* "tech(" keyword:[a-z0-9A-Z-]+ ")" { return keyword.join(""); }
 
 localEntry
   = "local(" value:value ")" { return {local: value}; }

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,10 +16,12 @@ export type FontFaceSrcItem = {
     local: string;
     url: never;
     format: never;
+    tech: never;
 } | {
     local: never;
     url: string;
     format?: string;
+    tech?: string;
 };
 
 export function parse(fontFaceSourceValue: string): FontFaceSrcItem[] {

--- a/test/jest/index.test.ts
+++ b/test/jest/index.test.ts
@@ -44,6 +44,38 @@ describe("Parser", () => {
                 format: 'woff'
             }]);
         });
+        
+        it("should parse a single url value with keyword format", () => {
+            const parse = parser.parse('url("font.woff") format(woff)');
+
+            expect(parse).toEqual([{
+                url: 'font.woff',
+                format: 'woff'
+            }]);
+        });
+        
+        it("should parse a single url value with tech", () => {
+            const parse = parser.parse('url("font.woff") tech(color-COLRv1)');
+
+            expect(parse).toEqual([{
+                url: 'font.woff',
+                tech: 'color-COLRv1'
+            }]);
+        });
+        
+        it("should not allow quoted tech", () => {
+            expect(() => parser.parse('url("font.woff") tech("features-graphite")')).toThrow();
+        });
+        
+        it("should parse a single url value with format and tech", () => {
+            const parse = parser.parse('url("font.woff") format("woff") tech(variations)');
+
+            expect(parse).toEqual([{
+                url: 'font.woff',
+                format: 'woff',
+                tech: 'variations',
+            }]);
+        });
 
         it("should parse a mix of multiple values", () => {
             const parse = parser.parse("local('The Font'), url( 'font.otf') format('opentype'), url(font.woff), local(\"Another Font\")");
@@ -70,12 +102,13 @@ describe("Parser", () => {
             }]);
         });
 
-        it("should parse white space between a format", () => {
-            const parse = parser.parse('url("font.woff") \t\r\n\fformat("woff")');
+        it("should parse white space between format & tech", () => {
+            const parse = parser.parse('url("font.woff") \t\r\n\fformat("woff")\t\r\ntech(variations)');
 
             expect(parse).toEqual([{
                 url: 'font.woff',
-                format: 'woff'
+                format: 'woff',
+                tech: 'variations',
             }]);
         });
 


### PR DESCRIPTION
Hi @cburgmer and thanks for the package, just used it to replace postcss-discard-font-face and works like a charm. I made a small update to support CSS Fonts level 4 — it has two major changes:

- `format(woff)` allows unquoted keywords, which this package already supports.
- Optional `tech()` fragment: https://www.w3.org/TR/css-fonts-4/#font-tech-definitions 

Both features are supported since chrome 108 / iOS 17 (see MDN). Some valid src values this parser fails on:

```
url("path/to/fontCOLR-svg.otf") tech(color-SVG)
url("path/to/fontCOLR-svg.otf") format("otf") tech(color-SVG)
```

See:
- [MDN article](https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/src)
- [Updated grammar](https://www.w3.org/TR/css-fonts-4/#font-face-src-parsing)

I added support for `tech()` both with and without `format()`, and exposed `tech` on `FontFaceSrcItem` type.

Technically, the spec restricts allowed keyword (unquoted) values for `tech` and `format`, so `url('font.woff') tech(fancy-tech)` and `url('font.woff') format(butt)` are invalid, but the parser allows these. I think this makes the library more resistant to spec changes, but let me know if you'd rater go with explicit keywords.

Would be great if we could merge and release this!